### PR TITLE
Lock html5lib version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     packages=['ankle'],
     install_requires=[
-        'html5lib>=0.9999999',
+        'html5lib==0.9999999',
         'six>=1.0'
     ]
 )


### PR DESCRIPTION
Lock version, because the change behavior after 0.99999999 (8 nines)

(Bug only in Python3)

See [StackoverFlow](http://stackoverflow.com/questions/39086278/html5lib-typeerror-init-got-an-unexpected-keyword-argument-encoding) for example
